### PR TITLE
Catch the completion to make the code work

### DIFF
--- a/EvilTalentSwift2/EvilTalentAPIClient.swift
+++ b/EvilTalentSwift2/EvilTalentAPIClient.swift
@@ -24,6 +24,7 @@ class EvilTalentAPIClient {
         guard let URL = NSURL(string: endPoint) else {
             return
         }
+        self.completion = completion
         let task = sharedSession.dataTaskWithURL(URL, completionHandler: parseServerData)
         task.resume()
     }


### PR DESCRIPTION
The completion has to be set to the property. Otherwise it would be nil later on. The tests still pass because they don't test this case.
